### PR TITLE
Fix readonly variable conflicts in utility modules

### DIFF
--- a/src/utils/logging.sh
+++ b/src/utils/logging.sh
@@ -11,11 +11,13 @@ set -euo pipefail
 # GLOBALE VARIABLEN UND KONSTANTEN
 # ===============================================================================
 
-# Log-Level Konstanten
-readonly LOG_LEVEL_DEBUG=0
-readonly LOG_LEVEL_INFO=1
-readonly LOG_LEVEL_WARN=2
-readonly LOG_LEVEL_ERROR=3
+# Log-Level Konstanten - only declare as readonly if not already set
+if [[ -z "${LOG_LEVEL_DEBUG:-}" ]]; then
+    readonly LOG_LEVEL_DEBUG=0
+    readonly LOG_LEVEL_INFO=1
+    readonly LOG_LEVEL_WARN=2
+    readonly LOG_LEVEL_ERROR=3
+fi
 
 # Standard-Konfiguration (wird von config/default.conf überschrieben)
 LOG_LEVEL="${LOG_LEVEL:-INFO}"
@@ -27,7 +29,15 @@ JSON_LOGGING="${JSON_LOGGING:-false}"
 LOG_TIMESTAMP_FORMAT="${LOG_TIMESTAMP_FORMAT:-%Y-%m-%dT%H:%M:%S%z}"
 
 # Interne Variablen
-SCRIPT_NAME=$(basename "$0")
+# Use conditional assignment to avoid readonly variable conflicts when sourced multiple times
+# Check if SCRIPT_NAME is already set (and possibly readonly) before trying to assign
+if [[ -z "${SCRIPT_NAME:-}" ]]; then
+    SCRIPT_NAME=$(basename "$0")
+elif ! readonly -p 2>/dev/null | grep -q "SCRIPT_NAME="; then
+    # SCRIPT_NAME is set but not readonly, so we can update it if needed
+    SCRIPT_NAME="${SCRIPT_NAME:-$(basename "$0")}"
+fi
+# If SCRIPT_NAME is readonly, we leave it as is
 LOG_PID=$$
 
 # ===============================================================================

--- a/src/utils/network.sh
+++ b/src/utils/network.sh
@@ -17,19 +17,23 @@ NETWORK_RETRY_COUNT="${NETWORK_RETRY_COUNT:-3}"
 NETWORK_RETRY_DELAY="${NETWORK_RETRY_DELAY:-5}"
 CONNECTIVITY_TEST_URL="${CONNECTIVITY_TEST_URL:-https://api.anthropic.com/v1/health}"
 
-# Zusätzliche Test-URLs für Redundanz
-readonly FALLBACK_URLS=(
-    "https://www.google.com"
-    "https://1.1.1.1"
-    "https://8.8.8.8"
-)
+# Zusätzliche Test-URLs für Redundanz - only declare as readonly if not already set
+if [[ -z "${FALLBACK_URLS:-}" ]]; then
+    readonly FALLBACK_URLS=(
+        "https://www.google.com"
+        "https://1.1.1.1"
+        "https://8.8.8.8"
+    )
+fi
 
-# DNS-Server für Tests
-readonly DNS_SERVERS=(
-    "8.8.8.8"
-    "1.1.1.1"
-    "9.9.9.9"
-)
+# DNS-Server für Tests - only declare as readonly if not already set
+if [[ -z "${DNS_SERVERS:-}" ]]; then
+    readonly DNS_SERVERS=(
+        "8.8.8.8"
+        "1.1.1.1"
+        "9.9.9.9"
+    )
+fi
 
 # ===============================================================================
 # HILFSFUNKTIONEN

--- a/src/utils/terminal.sh
+++ b/src/utils/terminal.sh
@@ -18,17 +18,19 @@ TERMINAL_TITLE="${TERMINAL_TITLE:-Claude Auto-Resume}"
 AUTO_CLOSE_TERMINAL="${AUTO_CLOSE_TERMINAL:-false}"
 APPLESCRIPT_INTEGRATION="${APPLESCRIPT_INTEGRATION:-true}"
 
-# Terminal-App-Definitionen
-readonly TERMINAL_APPS=(
-    "iterm2:iTerm.app"
-    "iterm:iTerm.app"
-    "terminal:Terminal.app"
-    "gnome-terminal:gnome-terminal"
-    "konsole:konsole"
-    "xterm:xterm"
-    "alacritty:alacritty"
-    "kitty:kitty"
-)
+# Terminal-App-Definitionen - only declare as readonly if not already set
+if [[ -z "${TERMINAL_APPS:-}" ]]; then
+    readonly TERMINAL_APPS=(
+        "iterm2:iTerm.app"
+        "iterm:iTerm.app"
+        "terminal:Terminal.app"
+        "gnome-terminal:gnome-terminal"
+        "konsole:konsole"
+        "xterm:xterm"
+        "alacritty:alacritty"
+        "kitty:kitty"
+    )
+fi
 
 # Erkannte Terminal-Informationen
 DETECTED_TERMINAL=""


### PR DESCRIPTION
## Summary
- Resolves GitHub Issue #30 - Logging utility readonly variable conflict  
- Fixes systematic readonly variable conflicts across all utility modules
- Enables graceful handling of multiple sourcing scenarios

## Root Cause Analysis
**Main Issue**: Utility modules declared readonly variables unconditionally, causing conflicts when sourced multiple times (which happens during testing and dependency loading).

**Affected Variables**:
- SCRIPT_NAME in logging.sh (conflicted with hybrid-monitor.sh)
- LOG_LEVEL_DEBUG, LOG_LEVEL_INFO, etc. constants in logging.sh
- TERMINAL_APPS array in terminal.sh  
- FALLBACK_URLS and DNS_SERVERS arrays in network.sh

## Changes Made

### src/utils/logging.sh:
- **SCRIPT_NAME Handling**: Conditional assignment that respects existing readonly variables
- **Log Level Constants**: Conditional readonly declaration to prevent redefinition
- **Robust Sourcing**: Handles multiple sourcing scenarios gracefully

### src/utils/terminal.sh:
- **TERMINAL_APPS Array**: Conditional readonly declaration for terminal application definitions

### src/utils/network.sh:
- **FALLBACK_URLS Array**: Conditional readonly declaration for fallback connectivity URLs
- **DNS_SERVERS Array**: Conditional readonly declaration for DNS server definitions

## Testing
**Before**: Script failed with 'SCRIPT_NAME: Schreibgeschützte Variable' error
**After**: No more readonly variable conflicts, script executes normally

## Impact
- **Immediate**: Eliminates script execution failures due to readonly variable conflicts
- **Test Environment**: Enables proper function loading in integration tests
- **Development**: Modules can be sourced multiple times without errors
- **Reliability**: Improves overall script robustness and maintainability

🤖 Generated with [Claude Code](https://claude.ai/code)