### PR TITLE
Fix JSON logging syntax error

### DIFF
--- a/src/utils/logging.sh
+++ b/src/utils/logging.sh
@@ -172,7 +172,7 @@ create_json_log() {
     local caller="$4"
     
     cat <<EOF
-{"timestamp":"$(json_escape "$timestamp)","level":"$(json_escape "$level")","message":"$(json_escape "$message")","caller":"$(json_escape "$caller")","script":"$(json_escape "$SCRIPT_NAME")","pid":$LOG_PID}
+{"timestamp":"$(json_escape "$timestamp")","level":"$(json_escape "$level")","message":"$(json_escape "$message")","caller":"$(json_escape "$caller")","script":"$(json_escape "$SCRIPT_NAME")","pid":$LOG_PID}
 EOF
 }
 


### PR DESCRIPTION
## Summary
- Resolves GitHub Issue #26 - Syntax error in JSON logging function
- Fixes missing closing quote in json_escape command substitution
- Enables JSON logging functionality to work correctly

## Root Cause
Line 175 in src/utils/logging.sh had a syntax error:
```bash
# Before (broken):
{"timestamp":"$(json_escape "$timestamp)","level":...

# After (fixed):  
{"timestamp":"$(json_escape "$timestamp")","level":...
```

Missing closing quote in the command substitution caused ShellCheck parsing errors:
- SC1073: Couldn't parse this command expansion
- SC1083: This } is literal. Check expression (missing ;/\n?) or quote it
- SC1072: Expected end of $(..) expression

## Changes Made
- **Fixed Quote Escaping**: Added missing closing quote in json_escape command substitution
- **Verified Functionality**: JSON logging now generates properly formatted JSON

## Testing
**Before**: Syntax parsing errors prevented logging module from loading
**After**: 
```bash
# JSON output works correctly:
{"timestamp":"2025-08-08T21:55:00+0200","level":"INFO","message":"test message","caller":"test.sh:main():10","script":"bash","pid":75527}
```

## Impact
- **Logging Module**: Can now be loaded without syntax errors
- **JSON Functionality**: JSON logging feature is functional  
- **Dependencies**: Unblocks Issue #29 (Unit tests failing due to missing logging functions)
- **Test Infrastructure**: Enables proper logging module testing

🤖 Generated with [Claude Code](https://claude.ai/code)